### PR TITLE
Make dynamic grants for ecs and cert modules optional

### DIFF
--- a/packages/@aws-cdk/aws-ecs/lib/container-image.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/container-image.ts
@@ -17,8 +17,8 @@ export abstract class ContainerImage {
   /**
    * Reference an image in an ECR repository
    */
-  public static fromEcrRepository(repository: ecr.IRepository, tag: string = 'latest') {
-    return new EcrImage(repository, tag);
+  public static fromEcrRepository(repository: ecr.IRepository, tag: string = 'latest', noGrant?: boolean) {
+    return new EcrImage(repository, tag, noGrant);
   }
 
   /**

--- a/packages/@aws-cdk/aws-ecs/lib/images/ecr.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/images/ecr.ts
@@ -15,16 +15,20 @@ export class EcrImage extends ContainerImage {
    * 012345678910.dkr.ecr.<region-name>.amazonaws.com/<repository-name>@sha256:94afd1f2e64d908bc90dbca0035a5b567EXAMPLE.
    */
   public readonly imageName: string;
+  private noGrant: boolean | undefined;
 
   /**
    * Constructs a new instance of the EcrImage class.
    */
-  constructor(private readonly repository: ecr.IRepository, private readonly tag: string) {
+  constructor(private readonly repository: ecr.IRepository, private readonly tag: string, noGrant?: boolean) {
     super();
+    this.noGrant = noGrant;
   }
 
   public bind(_scope: Construct, containerDefinition: ContainerDefinition): ContainerImageConfig {
-    this.repository.grantPull(containerDefinition.taskDefinition.obtainExecutionRole());
+    if (!this.noGrant) {
+      this.repository.grantPull(containerDefinition.taskDefinition.obtainExecutionRole());
+    }
 
     return {
       imageName: this.repository.repositoryUriForTag(this.tag)

--- a/packages/@aws-cdk/aws-ecs/lib/log-drivers/aws-log-driver.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/log-drivers/aws-log-driver.ts
@@ -91,7 +91,16 @@ export class AwsLogDriver extends LogDriver {
         retention: this.props.logRetention || Infinity,
     });
 
-    // Don't need this if you've statically granted the permissions ahead of time
+    /**
+     * Note: We are commenting this out to remove the need for the iam:PutRolePolicy on the CDK
+     * deploy user which is sufficient for our uses, as we've statically granted the permission to
+     * the appropriate resource ahead of time, so we can limit the excessive permissions granted to
+     * the user.
+     *
+     * TODO: Before PRing this change back to the official CDK repo we need to make this an optional
+     * change instead to support both use cases, as the pre-existing dynamic grantWrite is intended
+     * for the use case described in this PR https://github.com/aws/aws-cdk/pull/1291
+     */
     // this.logGroup.grantWrite(containerDefinition.taskDefinition.obtainExecutionRole());
 
     return {

--- a/packages/@aws-cdk/aws-ecs/lib/log-drivers/aws-log-driver.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/log-drivers/aws-log-driver.ts
@@ -91,7 +91,8 @@ export class AwsLogDriver extends LogDriver {
         retention: this.props.logRetention || Infinity,
     });
 
-    this.logGroup.grantWrite(containerDefinition.taskDefinition.obtainExecutionRole());
+    // Don't need this if you've statically granted the permissions ahead of time
+    // this.logGroup.grantWrite(containerDefinition.taskDefinition.obtainExecutionRole());
 
     return {
       logDriver: 'awslogs',


### PR DESCRIPTION
This modifies the `aws-cdk-aws-ecs` and `aws-cdk-aws-certificatemanager` packages to reduce the up front privilege requirements of the user making a CDK deployment as follows:
- `ecs.ContainerImage.fromEcrRepository` no longer requires `iam:PutRolePolicy` when passed  `noGrant=true`
- `taskDefinition.addContainer` no longer requires `iam:PutRolePolicy`
- `new DnsValidatedCertificate` no longer requires `iam:CreateRole` when passed a `role` parameter in its `DnsValidatedCertificateProps` with the appropriate policies already attached

These changes appear to be inline with the design goals of the AWS CDK and we intend to make PRs to the official CDK repo, due to their positive response to Issue 3519 and from the design of the existing code allowing Roles to be passed in to the client APIs.